### PR TITLE
Tightening the regex logic for `-1` in intercepts & `grep` for grabbing relevant columns

### DIFF
--- a/R/regress.R
+++ b/R/regress.R
@@ -170,7 +170,7 @@ regress <- function(fnctl, formula, data,
   form_temp <- deparse(formula[[3]])
   form_temp <- unlist(strsplit(form_temp, "\\+"))
   form_temp <- trimws(form_temp, "both")
-  # Note from Yiqun: added the - sign split logic 
+  # Note from Yiqun: added the - sign split logic
   remove_int <- grepl("-\\s*1", form_temp)
   if (any(remove_int)) {
     form_temp <- gsub("-\\s*1","",form_temp)
@@ -583,11 +583,13 @@ regress <- function(fnctl, formula, data,
   
   # get number of predictors in overall model
   p <- length(terms)
+  
   # process terms and get correct order for partial F-tests
   
   # need versions of terms and colnames(model) without parentheses for grep
   terms_noparens <- gsub("\\)", "", gsub("\\(", "", terms))
   colnames_model_noparens <- gsub("\\)", "", gsub("\\(", "", colnames(model)))
+  
   # get how many colons are present in each terms_noparens element
   num_colons <- unlist(lapply(strsplit(terms_noparens, ":"), length)) - 1
   

--- a/R/regress.R
+++ b/R/regress.R
@@ -170,9 +170,13 @@ regress <- function(fnctl, formula, data,
   form_temp <- deparse(formula[[3]])
   form_temp <- unlist(strsplit(form_temp, "\\+"))
   form_temp <- trimws(form_temp, "both")
-  remove_int <- grepl("-1", form_temp)
+  # Note from Yiqun: added the - sign split logic
+  remove_int <- grepl("-\\s*1", form_temp)
   if (any(remove_int)) {
-    form_temp <- paste(form_temp[!remove_int], collapse = "+")
+    form_temp <- gsub("-\\s*1","",form_temp)
+    form_temp <- trimws(form_temp, "both")
+    form_temp <- paste(form_temp, collapse = "+")
+    #form_temp <- paste(form_temp[!remove_int], collapse = "+")
     formula <- stats::as.formula(paste(unlist(strsplit(deparse(formula),"~"))[1], "~", form_temp), env = .GlobalEnv)
     intercept <- FALSE
   }

--- a/R/regress.R
+++ b/R/regress.R
@@ -170,7 +170,7 @@ regress <- function(fnctl, formula, data,
   form_temp <- deparse(formula[[3]])
   form_temp <- unlist(strsplit(form_temp, "\\+"))
   form_temp <- trimws(form_temp, "both")
-  # Note from Yiqun: added the - sign split logic
+  # Note from Yiqun: added the - sign split logic 
   remove_int <- grepl("-\\s*1", form_temp)
   if (any(remove_int)) {
     form_temp <- gsub("-\\s*1","",form_temp)
@@ -583,13 +583,11 @@ regress <- function(fnctl, formula, data,
   
   # get number of predictors in overall model
   p <- length(terms)
-  
   # process terms and get correct order for partial F-tests
   
   # need versions of terms and colnames(model) without parentheses for grep
   terms_noparens <- gsub("\\)", "", gsub("\\(", "", terms))
   colnames_model_noparens <- gsub("\\)", "", gsub("\\(", "", colnames(model)))
-  
   # get how many colons are present in each terms_noparens element
   num_colons <- unlist(lapply(strsplit(terms_noparens, ":"), length)) - 1
   
@@ -613,8 +611,7 @@ regress <- function(fnctl, formula, data,
     }
     
     # which columns does this term correspond to
-    which_cols <- grep(terms_noparens[i], colnames_model_noparens)
-    
+    which_cols <- grep(paste0("^",terms_noparens[i]), colnames_model_noparens)
     # if length(which_cols) == 0, this means the model is looking for an interaction between two
     # variables, at least one of which is a multi-level categorical variable
     if (length(which_cols) == 0) {
@@ -656,13 +653,12 @@ regress <- function(fnctl, formula, data,
       } else {
         # if this term is an interaction, ensure we're only picking up the appropriate interactions
         # (i.e. don't pick up the three-way interactions if this is only a two-level interaction)
-        num_colons[i]
+        # num_colons[i]
         num_colons_colnames <- unlist(lapply(strsplit(colnames_model_noparens[which_cols], ":"), length)) - 1
         which_cols <- which_cols[num_colons_colnames == num_colons[i]]
       }
       
     }
-    
     z <- processTerm(z, model[, which_cols], terms[i])
   }
   

--- a/R/regress_utils.R
+++ b/R/regress_utils.R
@@ -883,8 +883,8 @@ myNext <- function(num, vec){
 #' @keywords internal
 #' @noRd
 reFormatReg <- function(p, h, mf){
-  polynomial <- grepl("polynomial", h)
-  dummy <- grepl("dummy", h)
+  polynomial <- grepl("polynomial\\(", h)
+  dummy <- grepl("dummy\\(", h)
   args <- as.list(h)
   
   parens <- grepl(")", p, fixed=TRUE)

--- a/R/regress_utils.R
+++ b/R/regress_utils.R
@@ -1204,14 +1204,19 @@ processTerm <- function (z, Term, TermName) {
       TermName_split <- unlist(strsplit(TermName,":"))
       
       if (length(TermName_split) == 1) {
-        predNms <- gsub(TermName, "", dimnames(Term)[[2]])
+        # this causes problem if other entries of the dimnames(Term)[[2]] contains 
+        # TermName as well
+        predNms <- gsub(paste0("^",TermName), "", dimnames(Term)[[2]])
       } else {
         dimnames_Term_split <- strsplit(dimnames(Term)[[2]], ":")
         
         for (i in 1:length(TermName_split)) {
           # if the term name is exactly equal to the dimname, don't replace it
           if (TermName_split[i] != dimnames_Term_split[[1]][i]) {
-            dimnames_Term_split <- lapply(dimnames_Term_split, function(x) {c(gsub(TermName_split[i], "", x[i]), x[-i])})
+            #cat("TermName2",dimnames_Term_split,"\n")
+            dimnames_Term_split <- lapply(dimnames_Term_split, 
+                                          function(x) {c(gsub(paste0("^",TermName_split[i]), "", x[i]), x[-i])})
+            
           }
           
         }
@@ -1238,7 +1243,7 @@ processTerm <- function (z, Term, TermName) {
     z$preds <- c(z$preds,TermName)
   }
   z$lastPred[nTerm] <- dim(z$X)[2]
-  z
+  return(z) 
 }
 
 

--- a/R/regress_utils.R
+++ b/R/regress_utils.R
@@ -1204,8 +1204,7 @@ processTerm <- function (z, Term, TermName) {
       TermName_split <- unlist(strsplit(TermName,":"))
       
       if (length(TermName_split) == 1) {
-        # this causes problem if other entries of the dimnames(Term)[[2]] contains 
-        # TermName as well
+        # only match strings that start with TermName 
         predNms <- gsub(paste0("^",TermName), "", dimnames(Term)[[2]])
       } else {
         dimnames_Term_split <- strsplit(dimnames(Term)[[2]], ":")
@@ -1213,9 +1212,7 @@ processTerm <- function (z, Term, TermName) {
         for (i in 1:length(TermName_split)) {
           # if the term name is exactly equal to the dimname, don't replace it
           if (TermName_split[i] != dimnames_Term_split[[1]][i]) {
-            #cat("TermName2",dimnames_Term_split,"\n")
-            dimnames_Term_split <- lapply(dimnames_Term_split, 
-                                          function(x) {c(gsub(paste0("^",TermName_split[i]), "", x[i]), x[-i])})
+            dimnames_Term_split <- lapply(dimnames_Term_split, function(x) {c(gsub(paste0("^",TermName_split[i]), "", x[i]), x[-i])})
             
           }
           


### PR DESCRIPTION
Tightening the regex logic for `-1` in intercepts & `grep` for grabbing relevant columns; related to issues https://github.com/statdivlab/rigr/issues/103 and https://github.com/statdivlab/rigr/issues/102.