### PR TITLE
address issue #152, predictors dropped from large model

### DIFF
--- a/R/regress.R
+++ b/R/regress.R
@@ -211,6 +211,12 @@ regress <- function(fnctl, formula, data,
   # if intercept = FALSE, add a "-1" to the formula
   if (!intercept) {
     form <- deparse(formula)
+    # if formula is very long, deparse will split into several lines 
+    # (based on width.cutoff argument, default is 60)
+    # if this happens, paste it back into a single element 
+    if (length(form) > 1) {
+      form <- paste0(form, collapse = "")
+    }
     form <- paste(form, "-1")
     formula <- stats::as.formula(form, env=.GlobalEnv)
   }

--- a/tests/testthat/test_regress.R
+++ b/tests/testthat/test_regress.R
@@ -1260,3 +1260,15 @@ test_that("case diagnostics are correct", {
 #   expect_s3_class(influence.measures(mri_reg1), "infl") 
 #   
 # })
+
+test_that("regress works for a long formula", {
+  mri_complete <- mri[mri %>% complete.cases, ]
+  mri_tte <- survival::Surv(mri_complete$obstime, mri_complete$death)
+  expect_silent({
+    my_regress <- regress("hazard", mri_tte ~ height + weight + race + sex + age + dsst + atrophy +
+                          plt + sbp + fev + dsst + atrophy + chf + chf + alcoh, 
+                        data=mri_complete )
+  })
+  expect_equal(nrow(my_regress$coefficients), 14)
+  
+})

--- a/tests/testthat/test_regress.R
+++ b/tests/testthat/test_regress.R
@@ -1264,6 +1264,7 @@ test_that("case diagnostics are correct", {
 test_that("regress works for a long formula", {
   mri_complete <- mri[mri %>% complete.cases, ]
   mri_tte <- survival::Surv(mri_complete$obstime, mri_complete$death)
+  mri_complete$mri_tte <- mri_tte
   expect_silent({
     my_regress <- regress("hazard", mri_tte ~ height + weight + race + sex + age + dsst + atrophy +
                           plt + sbp + fev + dsst + atrophy + chf + chf + alcoh, 


### PR DESCRIPTION
This problem was caused by the `deparse()` function having a default `width.cutoff` of 60L beyond which it will create a line break, which was causing a bug with long formulas in the `regress` function. This PR addresses this bug and adds a test to make sure the example from issue #152 can be run without warning and without dropping coefficients from the output. 