### PR TITLE
Perform test of identical sample sizes in anova.uRegress() to address issue #158

### DIFF
--- a/R/anova.R
+++ b/R/anova.R
@@ -45,17 +45,12 @@ anova.uRegress <- function(object, full_object, test="LRT", robustSE = TRUE, use
     stop("uRegress objects must be entered!")
   }
   
-  if (!identical(object$fit$model, full_object$fit$model)) {
-    stop(paste0("The full and reduced models do not appear to be fit on the ",
+  if (NROW(object$fit$model) != NROW(full_object$fit$model)) {
+    stop(paste0("The full and reduced models are fit on data with different ",
+                "sample sizes, but the test is only valid when performed on the ",
                 "same dataset. This error often occurs when there is missing ",
-                "data in a variable that is included in the full model but not ",
-                "in the reduced model."))
+                "data in a variable that is included in the full model but not in the reduced model."))
   }
-  
-  # if (NROW(object$fit$model) == NROW(full_object$fit$model)) {
-  #   stop(paste0("The full and reduced models are fit on data with different",
-  #               "sample sizes."))
-  # }
   
   if(!(test %in% c("Wald","LRT"))){
     stop("Only Wald and LRT tests are available.")

--- a/R/anova.R
+++ b/R/anova.R
@@ -45,6 +45,17 @@ anova.uRegress <- function(object, full_object, test="LRT", robustSE = TRUE, use
     stop("uRegress objects must be entered!")
   }
   
+  if (!identical(object$fit$model, full_object$fit$model)) {
+    stop(paste0("The full and reduced models do not appear to be fit on the same",
+                "dataset. This error often occurs when there is missing data in",
+                "one variable that is only included in one of the models."))
+  }
+  
+  # if (NROW(object$fit$model) == NROW(full_object$fit$model)) {
+  #   stop(paste0("The full and reduced models are fit on data with different",
+  #               "sample sizes. This often suggests "))
+  # }
+  
   if(!(test %in% c("Wald","LRT"))){
     stop("Only Wald and LRT tests are available.")
   }

--- a/R/anova.R
+++ b/R/anova.R
@@ -48,8 +48,8 @@ anova.uRegress <- function(object, full_object, test="LRT", robustSE = TRUE, use
   if (!identical(object$fit$model, full_object$fit$model)) {
     stop(paste0("The full and reduced models do not appear to be fit on the ",
                 "same dataset. This error often occurs when there is missing ",
-                "data in one variable that is only included in one of the ",
-                "models."))
+                "data in a variable that is included in the full model but not ",
+                "in the reduced model."))
   }
   
   # if (NROW(object$fit$model) == NROW(full_object$fit$model)) {

--- a/R/anova.R
+++ b/R/anova.R
@@ -46,14 +46,15 @@ anova.uRegress <- function(object, full_object, test="LRT", robustSE = TRUE, use
   }
   
   if (!identical(object$fit$model, full_object$fit$model)) {
-    stop(paste0("The full and reduced models do not appear to be fit on the same",
-                "dataset. This error often occurs when there is missing data in",
-                "one variable that is only included in one of the models."))
+    stop(paste0("The full and reduced models do not appear to be fit on the ",
+                "same dataset. This error often occurs when there is missing ",
+                "data in one variable that is only included in one of the ",
+                "models."))
   }
   
   # if (NROW(object$fit$model) == NROW(full_object$fit$model)) {
   #   stop(paste0("The full and reduced models are fit on data with different",
-  #               "sample sizes. This often suggests "))
+  #               "sample sizes."))
   # }
   
   if(!(test %in% c("Wald","LRT"))){

--- a/tests/testthat/test_anova.R
+++ b/tests/testthat/test_anova.R
@@ -7,6 +7,23 @@ reg_full <- regress("mean", y ~ x + z, data = dat, robustSE = FALSE)
 lm_null <- stats::lm(y ~ x, data = dat)
 lm_full <- stats::lm(y ~ x + z, data = dat)
 
+dat_miss <- dat
+dat_miss$x[sample(1:100, 10)] <- NA
+reg_full_miss <- regress("mean", y ~ x1+x2, data = dat_miss)
+reg_null_miss <- regress("mean", y ~ x2, data = dat_miss)
+
+test_that("anova.uRegress() throws an error if models are fit on different sample sizes", {
+            expect_error(anova(reg_null_miss, reg_full_miss),
+                         paste0("The full and reduced models are fit on data with different ",
+                                "sample sizes, but the test is only valid when performed on the ",
+                                "same dataset. This error often occurs when there is missing ",
+                                "data in a variable that is included in the full model but not in the reduced model."))
+          })
+
+test_that("anova.uRegress() does not throw an error if models are fit on same sample size", {
+  expect_no_error(anova(reg_null, reg_full, robustSE = FALSE))
+})
+
 
 test_that("anova.uRegress() throws an error if at least one of the two input 
           objects is not of class uRegress", {


### PR DESCRIPTION
This pull request addresses issue #158 by checking that the sample sizes of the full and reduced models included in `rigr::anova.uRegress()` are fit on identical sample sizes (as a surrogate check that the models are fitted on identical data among shared variables). This was a problem when a variable included in the full model contained missing data, for which the default action in `rigr::regress()` is to subset to complete cases, however this makes the anova test invalid without further consideration.